### PR TITLE
Fix for external secret issue & README lint cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 This Validated Pattern implements an enterprise-ready Question & Answer chat application based on the Open Platform for Enterprise AI (OPEA) framework, accelerated by AMD Instinct GPUs. It provides a production-grade deployment pattern that combines OPEA's open-source AI capabilities with AMD's hardware acceleration, all orchestrated through OpenShift's enterprise platform.
 
 ### Key Features
+
 - 🚀 AMD Instinct GPU acceleration for high-performance AI inference
 - 🔒 Enterprise-grade security with HashiCorp Vault integration
 - 🤖 OPEA-based AI/ML pipeline with specialized services for document processing
@@ -44,25 +45,29 @@ The solution consists of several key components:
 ## 🚀 Getting Started
 
 ### Prerequisites
+
 - OpenShift 4.[16-18] cluster
 - AMD Instinct GPU(s)
-- Llama-3.1-8B-Instruct model (or compatible model for vLLM)
+- Llama-3.1-8B-Instruct model (or other [compatible model](https://github.com/opea-project/GenAIComps/tree/main/comps/llms/src/text-generation#validated-llm-models))
 
 ### Installation
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/your-org/qna-chat-amd.git
    cd qna-chat-amd
    ```
 
 2. Configure your environment:
+
    ```bash
    cp values-secret.yaml.template values-secret.yaml
    # Edit values-secret.yaml with your configuration (already added to .gitignore)
    ```
 
 3. Deploy the pattern:
+
    ```bash
    ./pattern.sh make install
    ```
@@ -70,11 +75,13 @@ The solution consists of several key components:
 ### Testing
 
 Run the test suite:
+
 ```bash
 make test
 ```
 
 Run the linter:
+
 ```bash
 make lint
 ```

--- a/charts/all/init-secret/templates/external-secret-endpoint-cert.yaml
+++ b/charts/all/init-secret/templates/external-secret-endpoint-cert.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.external_cert_enabled }}
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret
 metadata:
@@ -19,3 +20,4 @@ spec:
       remoteRef:
         key: {{ .Values.secret.endpoint_cert.vault.path }}
         property: {{ .Values.secret.endpoint_cert.vault.key }}
+  {{- end }}

--- a/charts/all/init-secret/values.yaml
+++ b/charts/all/init-secret/values.yaml
@@ -2,6 +2,8 @@ global:
   amdllm:
     namespace: amd-llm
 
+# external_cert_enabled: true # if true, values-secret should instantiate a matching vault secret source!
+
 secret:
   hugging_face:
     ocp:

--- a/charts/all/llm/templates/llm-deployment.yaml
+++ b/charts/all/llm/templates/llm-deployment.yaml
@@ -33,6 +33,12 @@ spec:
               value: {{ .value }}
             {{- end }}
             {{- end }}
+            {{- if .Values.external_cert_enabled }}
+            - name: SSL_CERT_FILE
+              value: /tmp/bundle.crtzs
+            - name: REQUESTS_CA_BUNDLE
+              value: /tmp/bundle.crt
+            {{- end }}
             {{- if .Values.global.amdllm.secret_env }}
             {{- range .Values.global.amdllm.secret_env }}
             - name: {{ .name }}

--- a/charts/all/llm/values.yaml
+++ b/charts/all/llm/values.yaml
@@ -3,6 +3,8 @@ global:
 
   clusterDomain: lab.com
 
+  # external_cert_enabled: true # if true, values-secret should instantiate a matching vault secret source!
+
   amdllm:
     namespace: amd-llm
     build_envs: [] # http_proxy/https_prxy can be set here
@@ -40,10 +42,6 @@ global:
         value: /tmp/temp-data
       - name: PYTHONPATH
         value: /home/user/.local/lib/python3.11/site-packages:/home/user
-      - name: SSL_CERT_FILE
-        value: /tmp/bundle.crt
-      - name: REQUESTS_CA_BUNDLE
-        value: /tmp/bundle.crt
       - name: LLM_MODEL_ID
         value: jary-serve
     volume:

--- a/tests/all-init-secret-industrial-edge-factory.expected.yaml
+++ b/tests/all-init-secret-industrial-edge-factory.expected.yaml
@@ -1,27 +1,4 @@
 ---
-# Source: init-secret/templates/external-secret-endpoint-cert.yaml
-apiVersion: "external-secrets.io/v1beta1"
-kind: ExternalSecret
-metadata:
-  name: endpoint-cert
-  namespace: amd-llm
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  refreshInterval: 15s
-  secretStoreRef:
-    name: vault-backend
-    kind: ClusterSecretStore
-  target:
-    name: endpoint-cert
-    template:
-      type: Opaque
-  data:
-    - secretKey: bundle.crt
-      remoteRef:
-        key: secret/hub/endpoint_cert
-        property: bundle.crt
----
 # Source: init-secret/templates/external-secret-hftoken.yaml
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret

--- a/tests/all-init-secret-industrial-edge-hub.expected.yaml
+++ b/tests/all-init-secret-industrial-edge-hub.expected.yaml
@@ -1,27 +1,4 @@
 ---
-# Source: init-secret/templates/external-secret-endpoint-cert.yaml
-apiVersion: "external-secrets.io/v1beta1"
-kind: ExternalSecret
-metadata:
-  name: endpoint-cert
-  namespace: amd-llm
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  refreshInterval: 15s
-  secretStoreRef:
-    name: vault-backend
-    kind: ClusterSecretStore
-  target:
-    name: endpoint-cert
-    template:
-      type: Opaque
-  data:
-    - secretKey: bundle.crt
-      remoteRef:
-        key: secret/hub/endpoint_cert
-        property: bundle.crt
----
 # Source: init-secret/templates/external-secret-hftoken.yaml
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret

--- a/tests/all-init-secret-medical-diagnosis-hub.expected.yaml
+++ b/tests/all-init-secret-medical-diagnosis-hub.expected.yaml
@@ -1,27 +1,4 @@
 ---
-# Source: init-secret/templates/external-secret-endpoint-cert.yaml
-apiVersion: "external-secrets.io/v1beta1"
-kind: ExternalSecret
-metadata:
-  name: endpoint-cert
-  namespace: amd-llm
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  refreshInterval: 15s
-  secretStoreRef:
-    name: vault-backend
-    kind: ClusterSecretStore
-  target:
-    name: endpoint-cert
-    template:
-      type: Opaque
-  data:
-    - secretKey: bundle.crt
-      remoteRef:
-        key: secret/hub/endpoint_cert
-        property: bundle.crt
----
 # Source: init-secret/templates/external-secret-hftoken.yaml
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret

--- a/tests/all-init-secret-naked.expected.yaml
+++ b/tests/all-init-secret-naked.expected.yaml
@@ -1,27 +1,4 @@
 ---
-# Source: init-secret/templates/external-secret-endpoint-cert.yaml
-apiVersion: "external-secrets.io/v1beta1"
-kind: ExternalSecret
-metadata:
-  name: endpoint-cert
-  namespace: amd-llm
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  refreshInterval: 15s
-  secretStoreRef:
-    name: vault-backend
-    kind: ClusterSecretStore
-  target:
-    name: endpoint-cert
-    template:
-      type: Opaque
-  data:
-    - secretKey: bundle.crt
-      remoteRef:
-        key: secret/hub/endpoint_cert
-        property: bundle.crt
----
 # Source: init-secret/templates/external-secret-hftoken.yaml
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret

--- a/tests/all-init-secret-normal.expected.yaml
+++ b/tests/all-init-secret-normal.expected.yaml
@@ -1,27 +1,4 @@
 ---
-# Source: init-secret/templates/external-secret-endpoint-cert.yaml
-apiVersion: "external-secrets.io/v1beta1"
-kind: ExternalSecret
-metadata:
-  name: endpoint-cert
-  namespace: amd-llm
-  annotations:
-    argocd.argoproj.io/sync-wave: "1"
-spec:
-  refreshInterval: 15s
-  secretStoreRef:
-    name: vault-backend
-    kind: ClusterSecretStore
-  target:
-    name: endpoint-cert
-    template:
-      type: Opaque
-  data:
-    - secretKey: bundle.crt
-      remoteRef:
-        key: secret/hub/endpoint_cert
-        property: bundle.crt
----
 # Source: init-secret/templates/external-secret-hftoken.yaml
 apiVersion: "external-secrets.io/v1beta1"
 kind: ExternalSecret

--- a/tests/all-llm-industrial-edge-factory.expected.yaml
+++ b/tests/all-llm-industrial-edge-factory.expected.yaml
@@ -54,10 +54,6 @@ spec:
               value: /tmp/temp-data
             - name: PYTHONPATH
               value: /home/user/.local/lib/python3.11/site-packages:/home/user
-            - name: SSL_CERT_FILE
-              value: /tmp/bundle.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /tmp/bundle.crt
             - name: LLM_MODEL_ID
               value: jary-serve
             - name: HF_TOKEN

--- a/tests/all-llm-industrial-edge-hub.expected.yaml
+++ b/tests/all-llm-industrial-edge-hub.expected.yaml
@@ -54,10 +54,6 @@ spec:
               value: /tmp/temp-data
             - name: PYTHONPATH
               value: /home/user/.local/lib/python3.11/site-packages:/home/user
-            - name: SSL_CERT_FILE
-              value: /tmp/bundle.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /tmp/bundle.crt
             - name: LLM_MODEL_ID
               value: jary-serve
             - name: HF_TOKEN

--- a/tests/all-llm-medical-diagnosis-hub.expected.yaml
+++ b/tests/all-llm-medical-diagnosis-hub.expected.yaml
@@ -54,10 +54,6 @@ spec:
               value: /tmp/temp-data
             - name: PYTHONPATH
               value: /home/user/.local/lib/python3.11/site-packages:/home/user
-            - name: SSL_CERT_FILE
-              value: /tmp/bundle.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /tmp/bundle.crt
             - name: LLM_MODEL_ID
               value: jary-serve
             - name: HF_TOKEN

--- a/tests/all-llm-naked.expected.yaml
+++ b/tests/all-llm-naked.expected.yaml
@@ -54,10 +54,6 @@ spec:
               value: /tmp/temp-data
             - name: PYTHONPATH
               value: /home/user/.local/lib/python3.11/site-packages:/home/user
-            - name: SSL_CERT_FILE
-              value: /tmp/bundle.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /tmp/bundle.crt
             - name: LLM_MODEL_ID
               value: jary-serve
             - name: HF_TOKEN

--- a/tests/all-llm-normal.expected.yaml
+++ b/tests/all-llm-normal.expected.yaml
@@ -54,10 +54,6 @@ spec:
               value: /tmp/temp-data
             - name: PYTHONPATH
               value: /home/user/.local/lib/python3.11/site-packages:/home/user
-            - name: SSL_CERT_FILE
-              value: /tmp/bundle.crt
-            - name: REQUESTS_CA_BUNDLE
-              value: /tmp/bundle.crt
             - name: LLM_MODEL_ID
               value: jary-serve
             - name: HF_TOKEN

--- a/values-secret.yaml.template
+++ b/values-secret.yaml.template
@@ -21,6 +21,11 @@ secrets:
       onMissingValue: prompt
       value: null
 
+  - name: endpoint_cert
+    fields:
+    - name: bundle.crt
+      value: null
+
   # If you use clusterPools you will need to uncomment the following lines
   #- name: aws
   #  fields:


### PR DESCRIPTION
- clean up lint errors left over from re-introduction
- make external LLM endpoint certificate params optional

NOTE: does not include any changes around the currently incorrect build.enabled var